### PR TITLE
Update OpenCL-Headers hash in build configuration for faster rebuilds

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,7 +5,7 @@
     .dependencies = .{
         .opencl_headers = .{
             .url = "https://github.com/KhronosGroup/OpenCL-Headers/archive/v2024.05.08.tar.gz",
-            .hash = "1220ad35211a500b402000c3fb50dbf5754a4cd41539cdde4b00195af47dde2cf36f",
+            .hash = "N-V-__8AAN3BBwCtNSEaUAtAIADD-1Db9XVKTNQVOc3eSwAZ",
         },
     },
 


### PR DESCRIPTION
> > Hi
> > ```
> > (.venv) ➜  tm2.zig git:(main) ✗ zig build run-imdb-spirv
> > /home/i/p/tm2.zig/opencl-zig/build.zig.zon:6:20: error: unable to connect to server: ConnectionTimedOut
> >             .url = "https://github.com/KhronosGroup/OpenCL-Headers/archive/v2024.05.08.tar.gz",
> >                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> > Time: 0h:02m:14s   
> > ```
> > 
> > The build had already run before, yet not only did it fail to connect (despite the files being cached), it also crashed after 2 minutes and 14 seconds.
How to prevent compiler to make requests to some third party servers on every re_build?
> 
> are you by any chance using the old hash format with the latest zig?

https://matrix.to/#/!mAmaFRcReXPBXGfKPT:tchncs.de/$TAZazPM7HOniG2cz1WdnuCTL_khy1JBDaT2XXws1Kl4?via=matrix.org&via=tchncs.de&via=envs.net